### PR TITLE
Add default Figma MCP server

### DIFF
--- a/src/services/mcp/defaultMcpServers.ts
+++ b/src/services/mcp/defaultMcpServers.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_MCP_SERVERS = {
+	"Framelink Figma MCP": {
+		command: "npx",
+		args: ["-y", "figma-developer-mcp", "--figma-api-key=YOUR-KEY", "--stdio"],
+	},
+} as const
+
+export type DefaultMcpServers = typeof DEFAULT_MCP_SERVERS


### PR DESCRIPTION
## Summary
- add Framelink Figma MCP default server configuration
- initialize new MCP settings files with the default servers
- merge default servers into existing settings automatically

## Testing
- `npm run lint`
- `npm run format`
- `npm run test:unit`
