### PR TITLE
Add design2code workflow

### DIFF
--- a/.clinerules/workflows/design2code.md
+++ b/.clinerules/workflows/design2code.md
@@ -1,0 +1,18 @@
+You can convert design files into code snippets. The user will provide a design link (Figma or similar). Use the Figma Developer MCP or the Remote Browser to inspect the design and generate corresponding code.
+
+<detailed_sequence_of_steps>
+# Design to Code Workflow
+1. Confirm the user has supplied a valid design link and what code format they expect (HTML/CSS, React, etc.).
+2. If the link is from Figma and the "Framelink Figma MCP" server is available:
+   - Call the appropriate MCP tool to fetch component data from the design. Example:
+     ```bash
+     mcp call "Framelink Figma MCP" generate-code --url <design link>
+     ```
+   - Extract the generated code snippet from the MCP response.
+3. If the Figma MCP isn't available or the link isn't a Figma URL:
+   - Open the design link using the Remote Browser.
+   - Capture screenshots and analyze the layout and styling.
+   - Translate the design into code manually using best practices.
+4. Present the resulting code snippet in a fenced code block.
+5. Ask the user if any adjustments or additional components are required.
+</detailed_sequence_of_steps>


### PR DESCRIPTION
## Summary
- add `/design2code` workflow for converting design links into code snippets

## Testing
- `npm run format:fix`
- `npm run lint`
- `npm test`
